### PR TITLE
Added paraphrase.py with contractions

### DIFF
--- a/decepticonlp/transforms/paraphrase.py
+++ b/decepticonlp/transforms/paraphrase.py
@@ -74,39 +74,33 @@ class ContractParaphrases(Paraphrases):
 
             assert "'" in text, self.get_not_a_contraction_error_message()
 
-            contraction_expansion_list=[
-                                        (r"\blet's\b", "let us"),
-                                        (r"\bwon't\b", "will not"),
-                                        (r"n't", " not"),
-                                        (r"'ve", " have"),
-                                        (r"'m", " am"),
-
+            contraction_expansion_list = [
+                (r"\blet's\b", "let us"),
+                (r"\bwon't\b", "will not"),
+                (r"n't", " not"),
+                (r"'ve", " have"),
+                (r"'m", " am"),
             ]
 
-            #Iterate over the pairs of the list
+            # Iterate over the pairs of the list
             for pair in contraction_expansion_list:
-                text=re.sub(pair[0],pair[1],text,flags=re.IGNORECASE)
-
+                text = re.sub(pair[0], pair[1], text, flags=re.IGNORECASE)
 
             # For contractions with multiple choices, choose the expansion arbitrarily
-            contraction_expansion_list_multiple=[
-                                                 (r"'s", [r" is", r" has"]),
-                                                 (r"'d", [r" had", r" would"]),
-                                                 (r"'ll", [r" will", r" shall"]),
-                                                 (r"'re", [r" are", r" were"])
-
-
+            contraction_expansion_list_multiple = [
+                (r"'s", [r" is", r" has"]),
+                (r"'d", [r" had", r" would"]),
+                (r"'ll", [r" will", r" shall"]),
+                (r"'re", [r" are", r" were"]),
             ]
-            
 
             choice = random.randint(0, 1)
 
-            #Iterate over the pairs of the list
+            # Iterate over the pairs of the list
             for pair in contraction_expansion_list_multiple:
-                text=re.sub(pair[0],pair[1][choice], text, flags=re.IGNORECASE)
+                text = re.sub(pair[0], pair[1][choice], text, flags=re.IGNORECASE)
             return text
 
-        
         if (
             kwargs.get("ignore", self.get_ignore_default_value())
             and len(text.split(" ")) < 2
@@ -116,7 +110,7 @@ class ContractParaphrases(Paraphrases):
         assert not len(text.split()) < 2, self.get_length_less_than_two_error_message()
 
         # Define text:contraction dictionary
-        expansion_contraction_list= [
+        expansion_contraction_list = [
             (r"\bwill not\b", "won't"),
             (r"\blet us\b", r"let's"),
             (r" not", r"n't"),

--- a/decepticonlp/transforms/paraphrase.py
+++ b/decepticonlp/transforms/paraphrase.py
@@ -73,25 +73,40 @@ class ContractParaphrases(Paraphrases):
                 return text
 
             assert "'" in text, self.get_not_a_contraction_error_message()
-            text = re.sub(r"\blet's\b", "let us", text, flags=re.IGNORECASE)
-            text = re.sub(r"\bwon't\b", "will not", text, flags=re.IGNORECASE)
-            text = re.sub(r"n't", " not", text, flags=re.IGNORECASE)
-            text = re.sub(r"'ve", " have", text, flags=re.IGNORECASE)
-            text = re.sub(r"'m", " am", text, flags=re.IGNORECASE)
+
+            contraction_expansion_list=[
+                                        (r"\blet's\b", "let us"),
+                                        (r"\bwon't\b", "will not"),
+                                        (r"n't", " not"),
+                                        (r"'ve", " have"),
+                                        (r"'m", " am"),
+
+            ]
+
+            #Iterate over the pairs of the list
+            for pair in contraction_expansion_list:
+                text=re.sub(pair[0],pair[1],text,flags=re.IGNORECASE)
+
 
             # For contractions with multiple choices, choose the expansion arbitrarily
-            list_for_s = [r" is", r" has"]
-            list_for_d = [r" had", r" would"]
-            list_for_ll = [r" will", r" shall"]
-            list_for_re = [r" are", r" were"]
+            contraction_expansion_list_multiple=[
+                                                 (r"'s", [r" is", r" has"]),
+                                                 (r"'d", [r" had", r" would"]),
+                                                 (r"'ll", [r" will", r" shall"]),
+                                                 (r"'re", [r" are", r" were"])
+
+
+            ]
+            
 
             choice = random.randint(0, 1)
-            text = re.sub(r"'s", list_for_s[choice], text, flags=re.IGNORECASE)
-            text = re.sub(r"'d", list_for_d[choice], text, flags=re.IGNORECASE)
-            text = re.sub(r"'ll", list_for_ll[choice], text, flags=re.IGNORECASE)
-            text = re.sub(r"'re", list_for_re[choice], text, flags=re.IGNORECASE)
+
+            #Iterate over the pairs of the list
+            for pair in contraction_expansion_list_multiple:
+                text=re.sub(pair[0],pair[1][choice], text, flags=re.IGNORECASE)
             return text
 
+        
         if (
             kwargs.get("ignore", self.get_ignore_default_value())
             and len(text.split(" ")) < 2
@@ -101,26 +116,24 @@ class ContractParaphrases(Paraphrases):
         assert not len(text.split()) < 2, self.get_length_less_than_two_error_message()
 
         # Define text:contraction dictionary
-        text_to_contraction = {
-            r"\blet us\b": r"let's",
-            r" not": r"n't",
-            r" have": r"'ve",
-            r" is": r"'s",
-            r" would": r"'d",
-            r" had": r"'d",
-            r" has": r"'s",
-            r" will": r"'ll",
-            r" shall": r"'ll",
-            r" are": r"'re",
-            r" were": r"'re",
-            r" am": r"'m",
-        }
+        expansion_contraction_list= [
+            (r"\bwill not\b", "won't"),
+            (r"\blet us\b", r"let's"),
+            (r" not", r"n't"),
+            (r" have", r"'ve"),
+            (r" is", r"'s"),
+            (r" would", r"'d"),
+            (r" had", r"'d"),
+            (r" has", r"'s"),
+            (r" will", r"'ll"),
+            (r" shall", r"'ll"),
+            (r" are", r"'re"),
+            (r" were", r"'re"),
+            (r" am", r"'m"),
+        ]
 
-        text = re.sub(r"\bwill not\b", "won't", text, flags=re.IGNORECASE)
         # Iterate over the keys of the dictionary and replace by contraction if found
-        for substring in text_to_contraction:
-            text = re.sub(
-                substring, text_to_contraction[substring], text, flags=re.IGNORECASE
-            )
+        for pair in expansion_contraction_list:
+            text = re.sub(pair[0], pair[1], text, flags=re.IGNORECASE)
 
         return text

--- a/decepticonlp/transforms/paraphrase.py
+++ b/decepticonlp/transforms/paraphrase.py
@@ -4,8 +4,9 @@ import re
 import random
 import abc
 
+
 class Paraphrases(metaclass=abc.ABCMeta):
-	"""
+    """
 		An abstract class used to represent paraphrases. SubClass should implement the apply method.
 		Methods
         -------
@@ -13,37 +14,35 @@ class Paraphrases(metaclass=abc.ABCMeta):
             - applies the paraphrasing on the text and returns it.
             """
 
+    @abc.abstractmethod
+    def apply(self, text: str, **kwargs):
+        """Applies paraphrasing and returns the text."""
+        raise NotImplementedError
 
-	@abc.abstractmethod
-	def apply(self, text:str, **kwargs):
-		"""Applies paraphrasing and returns the text."""
-		raise NotImplementedError
+    def get_ignore_default_value(self):
+        return True
 
+    def get_reverse_default_value(self):
+        return False
 
-	def get_ignore_default_value(self):
-		return True
-
-	def get_reverse_default_value(self):
-		return False
 
 class ContractParaphrases(Paraphrases):
-	"""
+    """
 	    A class used to apply contract paraphrasing.
 	    Methods
 	    -------
 	    apply(self, text: str, **kwargs)
 	        - applies the contract paraphrase on the word and returns it.
-	""" 
+	"""
 
-	def get_length_less_than_two_error_message(self):
-		return "given string's length is less than two"
+    def get_length_less_than_two_error_message(self):
+        return "given string's length is less than two"
 
-	def get_not_a_contraction_error_message(self):
-		return "given string is not a contraction"
+    def get_not_a_contraction_error_message(self):
+        return "given string is not a contraction"
 
-
-	def apply(self, text: str, **kwargs):
-		"""
+    def apply(self, text: str, **kwargs):
+        """
 		Contract words in the text (if reverse=False (default))
 
 		text=I would
@@ -66,57 +65,62 @@ class ContractParaphrases(Paraphrases):
 		:ignore: (boolean) default (True), boolean if assertions should be ignored
 		"""
 
-		if(kwargs.get("reverse",self.get_reverse_default_value())):
-			if(kwargs.get("ignore", self.get_ignore_default_value()) and '\'' not in text):
-				return text
-			
-			assert '\'' in text, self.get_not_a_contraction_error_message()
-			text=re.sub(r"\blet's\b", "let us", text, flags=re.IGNORECASE)
-			text=re.sub(r"\bwon't\b", "will not",text, flags=re.IGNORECASE)
-			text=re.sub(r"n't", " not", text, flags=re.IGNORECASE)
-			text=re.sub(r"'ve", " have", text, flags=re.IGNORECASE)
-			text=re.sub(r"'m", " am", text, flags=re.IGNORECASE)
+        if kwargs.get("reverse", self.get_reverse_default_value()):
+            if (
+                kwargs.get("ignore", self.get_ignore_default_value())
+                and "'" not in text
+            ):
+                return text
 
-			#For contractions with multiple choices, choose the expansion arbitrarily
-			list_for_s=[r" is", r" has"]
-			list_for_d=[r" had", r" would"]
-			list_for_ll=[r" will", r" shall"]
-			list_for_re=[r" are", r" were"]
-			
-			choice=random.randint(0,1)
-			text=re.sub(r"'s", list_for_s[choice],text,flags=re.IGNORECASE)
-			text=re.sub(r"'d", list_for_d[choice],text,flags=re.IGNORECASE)
-			text=re.sub(r"'ll", list_for_ll[choice],text,flags=re.IGNORECASE)
-			text=re.sub(r"'re", list_for_re[choice],text,flags=re.IGNORECASE)
-			return text
-			
+            assert "'" in text, self.get_not_a_contraction_error_message()
+            text = re.sub(r"\blet's\b", "let us", text, flags=re.IGNORECASE)
+            text = re.sub(r"\bwon't\b", "will not", text, flags=re.IGNORECASE)
+            text = re.sub(r"n't", " not", text, flags=re.IGNORECASE)
+            text = re.sub(r"'ve", " have", text, flags=re.IGNORECASE)
+            text = re.sub(r"'m", " am", text, flags=re.IGNORECASE)
 
+            # For contractions with multiple choices, choose the expansion arbitrarily
+            list_for_s = [r" is", r" has"]
+            list_for_d = [r" had", r" would"]
+            list_for_ll = [r" will", r" shall"]
+            list_for_re = [r" are", r" were"]
 
-		if (kwargs.get("ignore", self.get_ignore_default_value()) and len(text.split(" ")) < 2):
-			return text
-		
-		assert not len(text.split())<2, self.get_length_less_than_two_error_message()
-		
-		#Define text:contraction dictionary
-		text_to_contraction={
-		r"\blet us\b":r"let's",
-		r" not":r"n't",
-		r" have":r"'ve",
-		r" is":r"'s",
-		r" would":r"'d",
-		r" had":r"'d",
-		r" has":r"'s",
-		r" will":r"'ll",
-		r" shall":r"'ll",
-		r" are":r"'re",
-		r" were":r"'re",
-		r" am":r"'m"
-		}
+            choice = random.randint(0, 1)
+            text = re.sub(r"'s", list_for_s[choice], text, flags=re.IGNORECASE)
+            text = re.sub(r"'d", list_for_d[choice], text, flags=re.IGNORECASE)
+            text = re.sub(r"'ll", list_for_ll[choice], text, flags=re.IGNORECASE)
+            text = re.sub(r"'re", list_for_re[choice], text, flags=re.IGNORECASE)
+            return text
 
-		
-		text=re.sub(r"\bwill not\b", "won't", text, flags=re.IGNORECASE)
-		#Iterate over the keys of the dictionary and replace by contraction if found
-		for substring in text_to_contraction:
-			text=re.sub(substring,text_to_contraction[substring],text,flags=re.IGNORECASE)
+        if (
+            kwargs.get("ignore", self.get_ignore_default_value())
+            and len(text.split(" ")) < 2
+        ):
+            return text
 
-		return text
+        assert not len(text.split()) < 2, self.get_length_less_than_two_error_message()
+
+        # Define text:contraction dictionary
+        text_to_contraction = {
+            r"\blet us\b": r"let's",
+            r" not": r"n't",
+            r" have": r"'ve",
+            r" is": r"'s",
+            r" would": r"'d",
+            r" had": r"'d",
+            r" has": r"'s",
+            r" will": r"'ll",
+            r" shall": r"'ll",
+            r" are": r"'re",
+            r" were": r"'re",
+            r" am": r"'m",
+        }
+
+        text = re.sub(r"\bwill not\b", "won't", text, flags=re.IGNORECASE)
+        # Iterate over the keys of the dictionary and replace by contraction if found
+        for substring in text_to_contraction:
+            text = re.sub(
+                substring, text_to_contraction[substring], text, flags=re.IGNORECASE
+            )
+
+        return text

--- a/decepticonlp/transforms/paraphrase.py
+++ b/decepticonlp/transforms/paraphrase.py
@@ -1,0 +1,122 @@
+_author_ = "Abheesht Sharma"
+
+import re
+import random
+import abc
+
+class Paraphrases(metaclass=abc.ABCMeta):
+	"""
+		An abstract class used to represent paraphrases. SubClass should implement the apply method.
+		Methods
+        -------
+        apply(self, text: str, **kwargs)
+            - applies the paraphrasing on the text and returns it.
+            """
+
+
+	@abc.abstractmethod
+	def apply(self, text:str, **kwargs):
+		"""Applies paraphrasing and returns the text."""
+		raise NotImplementedError
+
+
+	def get_ignore_default_value(self):
+		return True
+
+	def get_reverse_default_value(self):
+		return False
+
+class ContractParaphrases(Paraphrases):
+	"""
+	    A class used to apply contract paraphrasing.
+	    Methods
+	    -------
+	    apply(self, text: str, **kwargs)
+	        - applies the contract paraphrase on the word and returns it.
+	""" 
+
+	def get_length_less_than_two_error_message(self):
+		return "given string's length is less than two"
+
+	def get_not_a_contraction_error_message(self):
+		return "given string is not a contraction"
+
+
+	def apply(self, text: str, **kwargs):
+		"""
+		Contract words in the text (if reverse=False (default))
+
+		text=I would
+		output=contract(text=text, reverse=False)
+		print(output)
+		I'd
+
+		text=He'll
+		output=contract(text=text, reverse=True)
+		print(output)
+		He will
+
+		Note: For reverse=True, this function does NOT disambiguate the output (eg: 's can be is/has). 
+			  For that, I would need to implement PoS Tagging (https://www.zora.uzh.ch/id/eprint/47923/4/Volk_Sennrich_Contraction_ResolutionV.pdf),
+			  take context into account and input a whole sentence/document rather than just a few words.
+
+		:param
+		:text: (str) if reverse is False, two or more words that are to be edited. If reverse is True, one word (the contraction)
+		:reverse: (boolean) default (False), word-->contraction. If True, contraction-->word
+		:ignore: (boolean) default (True), boolean if assertions should be ignored
+		"""
+
+		if(kwargs.get("reverse",self.get_reverse_default_value())):
+			if(kwargs.get("ignore", self.get_ignore_default_value()) and '\'' not in text):
+				return text
+			
+			assert '\'' in text, self.get_not_a_contraction_error_message()
+			text=re.sub(r"\blet's\b", "let us", text, flags=re.IGNORECASE)
+			text=re.sub(r"\bwon't\b", "will not",text, flags=re.IGNORECASE)
+			text=re.sub(r"n't", " not", text, flags=re.IGNORECASE)
+			text=re.sub(r"'ve", " have", text, flags=re.IGNORECASE)
+			text=re.sub(r"'m", " am", text, flags=re.IGNORECASE)
+
+			#For contractions with multiple choices, choose the expansion arbitrarily
+			list_for_s=[r" is", r" has"]
+			list_for_d=[r" had", r" would"]
+			list_for_ll=[r" will", r" shall"]
+			list_for_re=[r" are", r" were"]
+			
+			choice=random.randint(0,1)
+			text=re.sub(r"'s", list_for_s[choice],text,flags=re.IGNORECASE)
+			text=re.sub(r"'d", list_for_d[choice],text,flags=re.IGNORECASE)
+			text=re.sub(r"'ll", list_for_ll[choice],text,flags=re.IGNORECASE)
+			text=re.sub(r"'re", list_for_re[choice],text,flags=re.IGNORECASE)
+			return text
+			
+
+
+		if (kwargs.get("ignore", self.get_ignore_default_value()) and len(text.split(" ")) < 2):
+			return text
+		
+		assert not len(text.split())<2, self.get_length_less_than_two_error_message()
+		
+		#Define text:contraction dictionary
+		text_to_contraction={
+		r"\blet us\b":r"let's",
+		r" not":r"n't",
+		r" have":r"'ve",
+		r" is":r"'s",
+		r" would":r"'d",
+		r" had":r"'d",
+		r" has":r"'s",
+		r" will":r"'ll",
+		r" shall":r"'ll",
+		r" are":r"'re",
+		r" were":r"'re",
+		r" am":r"'m"
+		}
+
+		
+		text=re.sub(r"\bwill not\b", "won't", text, flags=re.IGNORECASE)
+		#Iterate over the keys of the dictionary and replace by contraction if found
+		for substring in text_to_contraction:
+			text=re.sub(substring,text_to_contraction[substring],text,flags=re.IGNORECASE)
+
+		return text

--- a/tests/test_paraphrase.py
+++ b/tests/test_paraphrase.py
@@ -4,40 +4,53 @@ from decepticonlp.transforms import paraphrase
 import random
 import pytest
 
-LENGTH_CONTRACTION_EXAMPLE="had"
-NOT_A_CONTRACTION_EXAMPLE="Shes"
+LENGTH_CONTRACTION_EXAMPLE = "had"
+NOT_A_CONTRACTION_EXAMPLE = "Shes"
+
 
 @pytest.mark.parametrize(
-	"text, expected_result",[("I had","I'd"), ("I would have","I'd've"), ("Rohan is","Rohan's"), ("I am","I'm"), ("They are", "They're")]
-	)
-
+    "text, expected_result",
+    [
+        ("I had", "I'd"),
+        ("I would have", "I'd've"),
+        ("Rohan is", "Rohan's"),
+        ("I am", "I'm"),
+        ("They are", "They're"),
+    ],
+)
 def test_paraphrase_contraction(text, expected_result):
-	random.seed(42)
-	contractions_apply=paraphrase.ContractParaphrases()
-	assert contractions_apply.apply(text, reverse=False, ignore=True) == expected_result
+    random.seed(42)
+    contractions_apply = paraphrase.ContractParaphrases()
+    assert contractions_apply.apply(text, reverse=False, ignore=True) == expected_result
 
 
 def test_paraphrase_contraction_length_assertion():
-	contractions_apply=paraphrase.ContractParaphrases()
-	with pytest.raises(AssertionError):
-		contractions_apply.apply(LENGTH_CONTRACTION_EXAMPLE, reverse=False, ignore=False)
+    contractions_apply = paraphrase.ContractParaphrases()
+    with pytest.raises(AssertionError):
+        contractions_apply.apply(
+            LENGTH_CONTRACTION_EXAMPLE, reverse=False, ignore=False
+        )
 
 
 @pytest.mark.parametrize(
-	"text, expected_result",[("He's","He has"), ("I'd've","I would have"),("They won't","They will not"), ("Let's","let us")]
-	)
-
+    "text, expected_result",
+    [
+        ("He's", "He has"),
+        ("I'd've", "I would have"),
+        ("They won't", "They will not"),
+        ("Let's", "let us"),
+    ],
+)
 def test_paraphrase_expansion(text, expected_result):
-	random.seed(41)
+    random.seed(41)
 
-	contractions_apply=paraphrase.ContractParaphrases()
-	assert contractions_apply.apply(text, reverse=True, ignore=True) == expected_result
+    contractions_apply = paraphrase.ContractParaphrases()
+    assert contractions_apply.apply(text, reverse=True, ignore=True) == expected_result
+
 
 def test_paraphrase_not_a_contraction_assertion():
-	contractions_apply=paraphrase.ContractParaphrases()
-	with pytest.raises(AssertionError):
-		assert contractions_apply.apply(NOT_A_CONTRACTION_EXAMPLE, reverse=True, ignore=False)
-
-
-
-
+    contractions_apply = paraphrase.ContractParaphrases()
+    with pytest.raises(AssertionError):
+        assert contractions_apply.apply(
+            NOT_A_CONTRACTION_EXAMPLE, reverse=True, ignore=False
+        )

--- a/tests/test_paraphrase.py
+++ b/tests/test_paraphrase.py
@@ -1,0 +1,43 @@
+_author_ = "Abheesht Sharma"
+
+from decepticonlp.transforms import paraphrase
+import random
+import pytest
+
+LENGTH_CONTRACTION_EXAMPLE="had"
+NOT_A_CONTRACTION_EXAMPLE="Shes"
+
+@pytest.mark.parametrize(
+	"text, expected_result",[("I had","I'd"), ("I would have","I'd've"), ("Rohan is","Rohan's"), ("I am","I'm"), ("They are", "They're")]
+	)
+
+def test_paraphrase_contraction(text, expected_result):
+	random.seed(42)
+	contractions_apply=paraphrase.ContractParaphrases()
+	assert contractions_apply.apply(text, reverse=False, ignore=True) == expected_result
+
+
+def test_paraphrase_contraction_length_assertion():
+	contractions_apply=paraphrase.ContractParaphrases()
+	with pytest.raises(AssertionError):
+		contractions_apply.apply(LENGTH_CONTRACTION_EXAMPLE, reverse=False, ignore=False)
+
+
+@pytest.mark.parametrize(
+	"text, expected_result",[("He's","He has"), ("I'd've","I would have"),("They won't","They will not"), ("Let's","let us")]
+	)
+
+def test_paraphrase_expansion(text, expected_result):
+	random.seed(41)
+
+	contractions_apply=paraphrase.ContractParaphrases()
+	assert contractions_apply.apply(text, reverse=True, ignore=True) == expected_result
+
+def test_paraphrase_not_a_contraction_assertion():
+	contractions_apply=paraphrase.ContractParaphrases()
+	with pytest.raises(AssertionError):
+		assert contractions_apply.apply(NOT_A_CONTRACTION_EXAMPLE, reverse=True, ignore=False)
+
+
+
+


### PR DESCRIPTION
I have added the contractions part, both for expanded phrase-->contraction and contraction-->expanded words. 

In the future, to improve this, we can implement PoS tagging, because right now, it will not be grammatically correct for certain contractions.